### PR TITLE
fix: fail lint on errors and align configs

### DIFF
--- a/apps/web/next-env.d.ts
+++ b/apps/web/next-env.d.ts
@@ -2,5 +2,4 @@
 /// <reference types="next/image-types/global" />
 
 // NOTE: This file should not be edited
-// see https://nextjs.org/docs/basic-features/typescript for more information.
-
+// see https://nextjs.org/docs/app/building-your-application/configuring/typescript for more information.

--- a/apps/web/next.config.mjs
+++ b/apps/web/next.config.mjs
@@ -1,0 +1,6 @@
+/** @type {import('next').NextConfig} */
+const nextConfig = {
+  reactStrictMode: true,
+};
+
+export default nextConfig;

--- a/apps/web/next.config.ts
+++ b/apps/web/next.config.ts
@@ -1,8 +1,0 @@
-import type { NextConfig } from 'next'
-
-const nextConfig: NextConfig = {
-  reactStrictMode: true,
-}
-
-export default nextConfig
-

--- a/apps/web/tsconfig.json
+++ b/apps/web/tsconfig.json
@@ -4,13 +4,20 @@
     "jsx": "preserve",
     "allowJs": true,
     "incremental": true,
-    "plugins": [{ "name": "next" }]
+    "plugins": [
+      {
+        "name": "next"
+      }
+    ],
+    "isolatedModules": true
   },
   "include": [
     "next-env.d.ts",
     "**/*.ts",
-    "**/*.tsx"
+    "**/*.tsx",
+    ".next/types/**/*.ts"
   ],
-  "exclude": ["node_modules"]
+  "exclude": [
+    "node_modules"
+  ]
 }
-

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "@types/node": "^20.11.30",
     "@typescript-eslint/eslint-plugin": "^7.18.0",
     "@typescript-eslint/parser": "^7.18.0",
-    "eslint": "^9.9.1",
+    "eslint": "^8.56.0",
     "typescript": "^5.5.4",
     "vitest": "^2.0.5"
   }

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -8,13 +8,13 @@
   "scripts": {
     "build": "tsc -p tsconfig.json",
     "typecheck": "tsc -p tsconfig.json --noEmit",
-    "lint": "eslint src --ext ts,tsx || echo 'eslint not configured'",
+    "lint": "eslint src --ext ts,tsx",
     "test": "vitest run"
   },
   "devDependencies": {
     "typescript": "^5.5.4",
     "vitest": "^2.0.5",
-    "eslint": "^9.9.1",
+    "eslint": "^8.56.0",
     "@typescript-eslint/eslint-plugin": "^7.18.0",
     "@typescript-eslint/parser": "^7.18.0"
   }

--- a/packages/types/tsconfig.json
+++ b/packages/types/tsconfig.json
@@ -5,7 +5,8 @@
     "outDir": "dist",
     "moduleResolution": "Bundler",
     "emitDeclarationOnly": false,
-    "isolatedModules": false
+    "isolatedModules": false,
+    "noEmit": false
   },
   "include": ["src/**/*.ts"]
 }


### PR DESCRIPTION
## Summary
- ensure @car-journal/types lint script fails on errors and pin ESLint to v8
- switch web app to next.config.mjs and commit Next.js tsconfig updates
- allow types package to emit build artifacts

## Testing
- `pnpm lint`
- `pnpm --filter @car-journal/types lint`
- `pnpm test`
- `pnpm --filter @car-journal/types build`
- `ls packages/types/dist`


------
https://chatgpt.com/codex/tasks/task_e_68b305f8ef408323b14c6d3e6f906605